### PR TITLE
Bugfix in ModSqrt.h

### DIFF
--- a/Implementations/content/number-theory (11.1)/Modular Arithmetic/ModSqrt.h
+++ b/Implementations/content/number-theory (11.1)/Modular Arithmetic/ModSqrt.h
@@ -13,7 +13,7 @@ T sqrt(mi a) {
 	if (p.v != 1) return p.v == 0 ? 0 : -1;
 	/// check if 0 or no sqrt
 	T s = MOD-1; int r = 0; while (s%2 == 0) s /= 2, ++r;
-	mi n = 1; while (pow(n,(MOD-1)/2).v != 1) n = T(n)+1; 
+	mi n = 2; while (pow(n,(MOD-1)/2).v == 1) n = T(n)+1; 
 	// n non-square, ord(g)=2^r, ord(b)=2^m, ord(g)=2^r, m<r
 	for (mi x = pow(a,(s+1)/2), b = pow(a,s), g = pow(n,s);;) {
 		if (b.v == 1) return min(x.v,MOD-x.v); // x^2=ab


### PR DESCRIPTION
The Shanks-Tonelli algorithm requires n to be a quadratic NONresidue, but the existing code was searching for any n that IS a quadratic residue. The comment below already reflects the correct version, so this mistake was probably just a typo.

If it would help, I'm happy to add a minimal demo proving it works now and didn't before. (Where would I put that?)